### PR TITLE
sys: use a shared implementation for common block attributes

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,3 +1,5 @@
+use crate::InternalBlockSize;
+
 #[derive(Debug, Clone)]
 pub struct Block {
     start_offset: u64,
@@ -12,16 +14,10 @@ impl Block {
     pub fn start_offset(&self) -> u64 {
         self.start_offset
     }
+}
 
-    pub fn compressed(&self) -> bool {
-        ((self.size) & (1 << 24)) == 0
-    }
-
-    pub fn on_disk_size(&self) -> u32 {
-        (self.size) & ((1 << 24) - 1)
-    }
-
-    pub fn is_spare(&self) -> bool {
-        self.on_disk_size() == 0
+impl InternalBlockSize for Block {
+    fn internal_size(&self) -> u32 {
+        self.size
     }
 }

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -7,7 +7,7 @@ use crate::ffi::{
 };
 use crate::file::File;
 use crate::super_block::SuperBlock;
-use crate::{ManagedPointer, Result};
+use crate::{InternalBlockSize, ManagedPointer, Result};
 
 /// Safe wrapper for [sqfs_frag_table_t]
 pub struct FragmentTable {
@@ -127,10 +127,13 @@ impl Fragment {
     pub fn start_offset(&self) -> u64 {
         self.fragment.start_offset
     }
-    pub fn size(&self) -> u32 {
-        self.fragment.size
-    }
     pub fn pad0(&self) -> u32 {
         self.fragment.pad0
+    }
+}
+
+impl InternalBlockSize for Fragment {
+    fn internal_size(&self) -> u32 {
+        self.fragment.size
     }
 }

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ptr::{slice_from_raw_parts, NonNull};
 
+use crate::BlockAttributes;
 use derive_more::Deref;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::FromPrimitive;
@@ -293,7 +294,7 @@ impl<'a> Iterator for Blocks<'a> {
             .get(self.index)
             .map(|&size| Block::new(self.start_offset, size));
         if let Some(block) = &block {
-            self.start_offset += u64::from(block.on_disk_size());
+            self.start_offset += u64::from(block.size());
         }
 
         self.index += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,3 +431,27 @@ fn path_to_c_str<P: AsRef<Path>>(path: P) -> Box<[u8]> {
 
     buf.into_boxed_slice()
 }
+
+trait InternalBlockSize {
+    fn internal_size(&self) -> u32;
+}
+
+pub trait BlockAttributes {
+    fn size(&self) -> u32;
+    fn is_compressed(&self) -> bool;
+    fn is_sparse(&self) -> bool;
+}
+
+impl<T: InternalBlockSize> BlockAttributes for T {
+    fn size(&self) -> u32 {
+        (self.internal_size()) & ((1 << 24) - 1)
+    }
+
+    fn is_compressed(&self) -> bool {
+        ((self.internal_size()) & (1 << 24)) == 0
+    }
+
+    fn is_sparse(&self) -> bool {
+        self.size() == 0
+    }
+}


### PR DESCRIPTION
leverage implementing traits on traits to share the implementation of size between block and fragment